### PR TITLE
refactor(api): moved handlers to their own files

### DIFF
--- a/functions/api.js
+++ b/functions/api.js
@@ -1,183 +1,42 @@
 const serverless = require('serverless-http');
 const express = require('express');
 const responseTimeMiddleware = require('./lib/response-time-middleware');
-const { all, single } = require('./lib/load-entities');
-const mergeVehiclesWithTransport = require('./lib/merge-vehicles-with-transport');
-const films = require('../data/films.json');
-const people = require('../data/people.json');
-const species = require('../data/species.json');
-const planets = require('../data/planets.json');
-const vehiclesTable = require('../data/vehicles.json');
-const starshipsTable = require('../data/starships.json');
-const transportsTable = require('../data/transport.json');
-const getServerName = require('./lib/get-server-name');
-
-const vehicles = mergeVehiclesWithTransport({
-  allVehicles: vehiclesTable,
-  allTransports: transportsTable,
-});
-
-const starships = mergeVehiclesWithTransport({
-  allVehicles: starshipsTable,
-  allTransports: transportsTable,
-});
-
+const { allFilms, singleFilm } = require('./handlers/films');
+const { allPeople, singlePerson } = require('./handlers/people');
+const { allPlanets, singlePlanet } = require('./handlers/planets');
+const { allSpecies, singleSpecies } = require('./handlers/species');
+const allResources = require('./handlers/resources');
+const { allStarships, singleStarship } = require('./handlers/starships');
+const { allVehicles, singleVehicle } = require('./handlers/vehicles');
 
 const app = express();
 
 app.use(responseTimeMiddleware);
 
-function catchAll(req, res) {
+app.get('/api', allResources);
+
+app.get('/api/films', allFilms);
+app.get('/api/films/:id', singleFilm);
+
+app.get('/api/people', allPeople);
+app.get('/api/people/:id', singlePerson);
+
+app.get('/api/planets', allPlanets);
+app.get('/api/planets/:id', singlePlanet);
+
+app.get('/api/species', allSpecies);
+app.get('/api/species/:id', singleSpecies);
+
+app.get('/api/starships', allStarships);
+app.get('/api/starships/:id', singleStarship);
+
+app.get('/api/vehicles', allVehicles);
+app.get('/api/vehicles/:id', singleVehicle);
+
+app.get('/*', (req, res) => {
   res.write('It works');
   res.end();
-}
-
-const peopleBacklinks = {
-  films: {
-    collection: films,
-    field: 'characters',
-  },
-  species: {
-    collection: species,
-    field: 'people',
-  },
-  vehicles: {
-    collection: vehicles,
-    field: 'pilots',
-  },
-  starships: {
-    collection: starships,
-    field: 'pilots',
-  },
-};
-
-
-app.get('/api/films', all({ prefix: 'films', entities: films, backlinks: undefined }));
-app.get('/api/films/:id', single({ prefix: 'films', entities: films, backlinks: undefined }));
-
-app.get('/api/people', all({
-  prefix: 'people',
-  entities: people,
-  backlinks: peopleBacklinks,
-}));
-app.get('/api/people/:id',
-  single({
-    prefix: 'people',
-    entities: people,
-    backlinks: peopleBacklinks,
-  }));
-
-app.get('/api/planets', all({
-  prefix: 'planets',
-  entities: planets,
-  backlinks: {
-    films: {
-      collection: films,
-      field: 'planets',
-    },
-    residents: {
-      collection: people,
-      field: 'homeworld',
-    },
-  },
-}));
-app.get('/api/planets/:id', single({
-  prefix: 'planets',
-  entities: planets,
-  backlinks: {
-    films: {
-      collection: films,
-      field: 'planets',
-    },
-    residents: {
-      collection: people,
-      field: 'homeworld',
-    },
-  },
-}));
-
-app.get('/api/species', all({
-  prefix: 'species',
-  entities: species,
-  backlinks: {
-    films: {
-      collection: films,
-      field: 'species',
-    },
-  },
-}));
-app.get('/api/species/:id', single({
-  prefix: 'species',
-  entities: species,
-  backlinks: {
-    films: {
-      collection: films,
-      field: 'species',
-    },
-  },
-}));
-
-app.get('/api/starships', all({
-  prefix: 'starships',
-  entities: starships,
-  backlinks: {
-    films: {
-      collection: films,
-      field: 'starships',
-    },
-  },
-}));
-app.get('/api/starships/:id', single({
-  prefix: 'starships',
-  entities: starships,
-  backlinks: {
-    films: {
-      collection: films,
-      field: 'starships',
-    },
-  },
-}));
-
-app.get('/api/vehicles', all({
-  prefix: 'vehicles',
-  entities: vehicles,
-  backlinks: {
-    films: {
-      collection: films,
-      field: 'vehicles',
-    },
-  },
-}));
-app.get('/api/vehicles/:id', single({
-  prefix: 'vehicles',
-  entities: vehicles,
-  backlinks: {
-    films: {
-      collection: films,
-      field: 'vehicles',
-    },
-  },
-}));
-
-app.get('/api', (req, res) => {
-  res.json([
-    'people',
-    'planets',
-    'films',
-    'species',
-    'vehicles',
-    'starships',
-  ].reduce(
-    (accumulator, prefix) => (
-      {
-        ...accumulator,
-        [prefix]: `${getServerName(req)}/api/${prefix}`,
-      }),
-    {}, // <- initial value
-  ));
 });
-
-app.get('/*', catchAll);
 
 module.exports = {
   handler: process.env.NODE_ENV === 'local' ? app : serverless(app),

--- a/functions/handlers/films.js
+++ b/functions/handlers/films.js
@@ -1,0 +1,17 @@
+const films = require('../../data/films.json');
+const { all, single } = require('../lib/load-entities');
+
+const params = { prefix: 'films', entities: films };
+
+function allFilms(req, res) {
+  all(params)(req, res);
+}
+
+function singleFilm(req, res) {
+  single(params)(req, res);
+}
+
+module.exports = {
+  allFilms,
+  singleFilm,
+};

--- a/functions/handlers/people.js
+++ b/functions/handlers/people.js
@@ -48,7 +48,7 @@ function allPeople(req, res) {
 }
 
 function singlePerson(req, res) {
-  single({ params })(req, res);
+  single(params)(req, res);
 }
 
 module.exports = {

--- a/functions/handlers/people.js
+++ b/functions/handlers/people.js
@@ -1,0 +1,57 @@
+const people = require('../../data/people.json');
+const films = require('../../data/films.json');
+const species = require('../../data/species.json');
+const vehiclesTable = require('../../data/vehicles.json');
+const starshipsTable = require('../../data/starships.json');
+const transportsTable = require('../../data/transport.json');
+
+const { all, single } = require('../lib/load-entities');
+const mergeVehiclesWithTransport = require('../lib/merge-vehicles-with-transport');
+
+const vehicles = mergeVehiclesWithTransport({
+  allVehicles: vehiclesTable,
+  allTransports: transportsTable,
+});
+
+const starships = mergeVehiclesWithTransport({
+  allVehicles: starshipsTable,
+  allTransports: transportsTable,
+});
+
+
+const params = {
+  prefix: 'people',
+  entities: people,
+  backlinks: {
+    films: {
+      collection: films,
+      field: 'characters',
+    },
+    species: {
+      collection: species,
+      field: 'people',
+    },
+    vehicles: {
+      collection: vehicles,
+      field: 'pilots',
+    },
+    starships: {
+      collection: starships,
+      field: 'pilots',
+    },
+  },
+};
+
+
+function allPeople(req, res) {
+  all(params)(req, res);
+}
+
+function singlePerson(req, res) {
+  single({ params })(req, res);
+}
+
+module.exports = {
+  allPeople,
+  singlePerson,
+};

--- a/functions/handlers/planets.js
+++ b/functions/handlers/planets.js
@@ -1,0 +1,32 @@
+const planets = require('../../data/planets.json');
+const films = require('../../data/films.json');
+const people = require('../../data/people.json');
+const { all, single } = require('../lib/load-entities');
+
+const params = {
+  prefix: 'planets',
+  entities: planets,
+  backlinks: {
+    films: {
+      collection: films,
+      field: 'planets',
+    },
+    residents: {
+      collection: people,
+      field: 'homeworld',
+    },
+  },
+};
+
+function allPlanets(req, res) {
+  all(params)(req, res);
+}
+
+function singlePlanet(req, res) {
+  single(params)(req, res);
+}
+
+module.exports = {
+  allPlanets,
+  singlePlanet,
+};

--- a/functions/handlers/resources.js
+++ b/functions/handlers/resources.js
@@ -1,0 +1,21 @@
+const getServerName = require('../lib/get-server-name');
+
+function allResources(req, res) {
+  res.json([
+    'people',
+    'planets',
+    'films',
+    'species',
+    'vehicles',
+    'starships',
+  ].reduce(
+    (accumulator, prefix) => (
+      {
+        ...accumulator,
+        [prefix]: `${getServerName(req)}/api/${prefix}`,
+      }),
+    {}, // <- initial value
+  ));
+}
+
+module.exports = allResources;

--- a/functions/handlers/species.js
+++ b/functions/handlers/species.js
@@ -1,0 +1,29 @@
+const species = require('../../data/species.json');
+const films = require('../../data/films.json');
+const { all, single } = require('../lib/load-entities');
+
+const PREFIX = 'planets';
+
+const params = {
+  prefix: PREFIX,
+  entities: species,
+  backlinks: {
+    films: {
+      collection: films,
+      field: 'species',
+    },
+  },
+};
+
+function allSpecies(req, res) {
+  all(params)(req, res);
+}
+
+function singleSpecies(req, res) {
+  single(params)(req, res);
+}
+
+module.exports = {
+  allSpecies,
+  singleSpecies,
+};

--- a/functions/handlers/starships.js
+++ b/functions/handlers/starships.js
@@ -1,0 +1,35 @@
+const films = require('../../data/films.json');
+const { all, single } = require('../lib/load-entities');
+const mergeVehiclesWithTransport = require('../lib/merge-vehicles-with-transport');
+
+const starshipsTable = require('../../data/starships.json');
+const transportsTable = require('../../data/transport.json');
+
+const starships = mergeVehiclesWithTransport({
+  allVehicles: starshipsTable,
+  allTransports: transportsTable,
+});
+
+const params = {
+  prefix: 'starships',
+  entities: starships,
+  backlinks: {
+    films: {
+      collection: films,
+      field: 'starships',
+    },
+  },
+};
+
+function allStarships(req, res) {
+  all(params)(req, res);
+}
+
+function singleStarship(req, res) {
+  single(params)(req, res);
+}
+
+module.exports = {
+  allStarships,
+  singleStarship,
+};

--- a/functions/handlers/vehicles.js
+++ b/functions/handlers/vehicles.js
@@ -1,0 +1,35 @@
+const films = require('../../data/films.json');
+const { all, single } = require('../lib/load-entities');
+const mergeVehiclesWithTransport = require('../lib/merge-vehicles-with-transport');
+
+const vehiclesTable = require('../../data/vehicles.json');
+const transportsTable = require('../../data/transport.json');
+
+const vehicles = mergeVehiclesWithTransport({
+  allVehicles: vehiclesTable,
+  allTransports: transportsTable,
+});
+
+const params = {
+  prefix: 'vehicles',
+  entities: vehicles,
+  backlinks: {
+    films: {
+      collection: films,
+      field: 'vehicles',
+    },
+  },
+};
+
+function allVehicles(req, res) {
+  all(params)(req, res);
+}
+
+function singleVehicle(req, res) {
+  single(params)(req, res);
+}
+
+module.exports = {
+  allVehicles,
+  singleVehicle,
+};


### PR DESCRIPTION
Moved all specific express handlers (e.g. /films, /planets, etc) to their own specific files.
This helped in reusing code, reducing the size of the codebase.