### PR TITLE
fix(homepage): fixed initial value of api URL

### DIFF
--- a/src/components/request-box.js
+++ b/src/components/request-box.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 function RequestBox({ initialCode }) {
   const [code, setCode] = useState();
-  const [currentRequest, setCurrentRequest] = useState();
+  const [currentRequest, setCurrentRequest] = useState('');
 
   useEffect(() => {
     setCode(initialCode);


### PR DESCRIPTION
Fixed initial value of API URL to '' instead of undefined. This way the initial request to /api is working as expected.